### PR TITLE
Add ability to replace history item with navigate

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ If the browser does not support pushState or you have set
 call and add it to `window.location.hash` so the url would
 look like this `"/admin#/users/all"`.
 
+If you wish to replace the history item instead pushing to the history list
+call `navigate` with the replace option: `Aviator.navigate('/users/all', { replace: true });`
+
 ## `Aviator.refresh`
 
 re-dispatch the current uri

--- a/aviator.js
+++ b/aviator.js
@@ -490,10 +490,19 @@
     /**
     @method navigate
     @param {String} uri
+    @param {Object} [options]
     **/
-    navigate: function (uri) {
+    navigate: function (uri, options) {
+      var options = options || {};
+
       if (this.pushStateEnabled) {
-        history.pushState(null, '', this.root + uri);
+        if (options.replace) {
+          history.replaceState(null, '', this.root + uri);
+        }
+        else {
+          history.pushState(null, '', this.root + uri);
+        }
+
         this.onURIChange();
       }
       else {
@@ -613,9 +622,10 @@
     /**
     @method navigate
     @param {String} uri to navigate to
+    @param {Object} [options]
     **/
-    navigate: function (uri) {
-      this._navigator.navigate(uri);
+    navigate: function (uri, options) {
+      this._navigator.navigate(uri, options);
     },
 
     /**

--- a/spec/aviator_spec.js
+++ b/spec/aviator_spec.js
@@ -77,16 +77,17 @@ describe('Aviator', function () {
   });
 
   describe('.navigate', function () {
-    var url = '/partners/whatever';
+    var url = '/partners/whatever',
+        opts = {};
 
     beforeEach(function () {
       spyOn( _navigator, 'navigate' );
 
-      subject.navigate( url );
+      subject.navigate( url, opts);
     });
 
     it('calls navigate on the navigator', function () {
-      expect( _navigator.navigate ).toHaveBeenCalledWith( url );
+      expect( _navigator.navigate ).toHaveBeenCalledWith( url, opts );
     });
   });
 

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -173,7 +173,7 @@ describe('Navigator', function () {
         spyOn( subject, 'onURIChange');
       });
 
-      it('adds the href to history with the root', function () {
+      it('pushes the href to history with the root', function () {
         var spy = spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
           expect( a ).toEqual( null );
           expect( b ).toBe( '' );
@@ -185,6 +185,15 @@ describe('Navigator', function () {
       it('calls onURIChange', function () {
         subject.navigate('/foo/bar');
         expect( subject.onURIChange ).toHaveBeenCalled();
+      });
+
+      describe('and called with replace: true', function () {
+        it('replaces the href to history with the root', function () {
+          spyOn( window.history, 'replaceState' ).andCallThrough();
+
+          subject.navigate('/foo/bar', { replace: true });
+          expect(window.history.replaceState).toHaveBeenCalled();
+        });
       });
     });
 


### PR DESCRIPTION
use `Aviator.navigate('/users/all', { replace: true });` to replace the
current history item instead of pushing to the url.

@barnabyc @flahertyb 
