### PR TITLE
Allow adding options without a method

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -242,6 +242,9 @@
                 this.actions.push(action);
               }
             }
+            else if (value.hasOwnProperty('options')) {
+              this.mergeOptions(value.options);
+            }
 
             if (isPlainObject(value)) {
               // recurse

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -161,6 +161,24 @@ describe('Route', function () {
           });
         });
 
+        describe('with options with no `method`', function () {
+          beforeEach(function () {
+            uri = '/users/catdog/edit';
+
+            navigator._routes['/users']['/:uuid']['/*'] = {
+              options: { renderCats: true }
+            };
+
+            subject = navigator.getRouteForURI(uri);
+          });
+
+          it('merges the options into one object', function () {
+            expect( subject.options ).toEqual({
+              showLayout: true,
+              renderCats: true
+            });
+          });
+        });
       });
     });
 


### PR DESCRIPTION
By allowing options without a method we can add options to a sub set of
routes:

``` javascript
Aviator.setRoutes({
  '/users': {
    target:     usersTarget,
    '/*':       { options: { bartyMcFly: true },
    '/:uuid':   'show',
    '/recent':  'listRecent'
  }
});
```

@barnabyc @flahertyb 
