### PR TITLE
Add Aviator.getCurrentRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Aviator exposes a small API:
 * `setRoutes`: parses the routes config object
 * `dispatch`: makes the routes go pew pew
 * `navigate`: routes a given path
-* `refresh`: re-dispatches the current uri
+* `refresh`: re-dispatches the current URI
+* `getCurrentURI`: get the currently matched URI
+* `getCurrentRequest`: get the currently matched Request
 
 ### Configuration properties
 

--- a/aviator.js
+++ b/aviator.js
@@ -381,34 +381,44 @@
     },
 
     /**
-    @method getRouteForURI
+    @method createRouteForURI
     @param {String} uri
     @return {Request}
     **/
-    getRouteForURI: function (uri) {
+    createRouteForURI: function (uri) {
       return new Route(this._routes, uri);
     },
 
     /**
-    @method getRequest
+    @method createRequest
     @param {String} uri
     @param {String|Null} queryString
     @param {String} matchedRoute
     @return {Request}
     **/
-    getRequest: function (uri, queryString, matchedRoute) {
-      return new Request({
+    createRequest: function (uri, queryString, matchedRoute) {
+      this._request = new Request({
         uri: uri,
         queryString: queryString,
         matchedRoute: matchedRoute
       });
+
+      return this._request;
     },
 
     /**
-    @method getURI
+    @method getCurrentRequest
+    @return {Request}
+    **/
+    getCurrentRequest: function () {
+      return this._request;
+    },
+
+    /**
+    @method getCurrentURI
     @return {String}
     **/
-    getURI: function () {
+    getCurrentURI: function () {
       if (this.pushStateEnabled) {
         return location.pathname.replace(this.root, '');
       }
@@ -429,11 +439,11 @@
     @method dispatch
     **/
     dispatch: function () {
-      var uri         = this.getURI(),
-          route       = this.getRouteForURI(uri),
+      var uri         = this.getCurrentURI(),
+          route       = this.createRouteForURI(uri),
           queryString = this.getQueryString(),
           options     = route.options,
-          request     = this.getRequest(
+          request     = this.createRequest(
             uri,
             queryString,
             route.matchedRoute
@@ -638,11 +648,19 @@
     },
 
     /**
-    @method getURI
+    @method getCurrentRequest
     @return {String}
     **/
-    getURI: function () {
-      return this._navigator.getURI();
+    getCurrentRequest: function () {
+      return this._navigator.getCurrentRequest();
+    },
+
+    /**
+    @method getCurrentURI
+    @return {String}
+    **/
+    getCurrentURI: function () {
+      return this._navigator.getCurrentURI();
     },
 
     /**

--- a/spec/aviator_spec.js
+++ b/spec/aviator_spec.js
@@ -54,14 +54,25 @@ describe('Aviator', function () {
 
   });
 
-  describe('.getURI', function () {
+  describe('.getCurrentRequest', function () {
     beforeEach(function () {
-      spyOn( _navigator, 'getURI' );
-      subject.getURI();
+      spyOn( _navigator, 'getCurrentRequest' );
+      subject.getCurrentRequest();
     });
 
-    it('calls getURI on the navigator', function () {
-      expect( _navigator.getURI ).toHaveBeenCalled();
+    it('calls getCurrentRequest on the navigator', function () {
+      expect( _navigator.getCurrentRequest ).toHaveBeenCalled();
+    });
+  });
+
+  describe('.getCurrentURI', function () {
+    beforeEach(function () {
+      spyOn( _navigator, 'getCurrentURI' );
+      subject.getCurrentURI();
+    });
+
+    it('calls getCurrentURI on the navigator', function () {
+      expect( _navigator.getCurrentURI ).toHaveBeenCalled();
     });
   });
 

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -19,7 +19,7 @@ describe('Navigator', function () {
     window.history.replaceState({}, '', '/_SpecRunner.html');
   });
 
-  describe('#getURI', function () {
+  describe('#getCurrentURI', function () {
     var root;
 
     beforeEach(function () {
@@ -39,7 +39,7 @@ describe('Navigator', function () {
         });
 
         it('returns /foo/bar', function () {
-          expect( subject.getURI() ).toBe( '/foo/bar' );
+          expect( subject.getCurrentURI() ).toBe( '/foo/bar' );
         });
       });
     });
@@ -55,9 +55,24 @@ describe('Navigator', function () {
         });
 
         it('returns /foo/bar', function () {
-          expect( subject.getURI() ).toBe( '/foo/bar' );
+          expect( subject.getCurrentURI() ).toBe( '/foo/bar' );
         });
       });
+    });
+  });
+
+  describe('getCurrentRequest', function () {
+    beforeEach(function () {
+      spyOn( subject, 'createRouteForURI' ).andReturn({
+        matchedRoute: '/users/:uuid',
+        actions: [ { method: 'show', target: usersTarget } ],
+        options: [ { leftNav: true }, { showLayout: false } ]
+      });
+      subject.dispatch();
+    });
+
+    it('returns the current request', function () {
+      expect( subject.getCurrentRequest() ).not.toBe( undefined );
     });
   });
 
@@ -236,7 +251,7 @@ describe('Navigator', function () {
 
       describe('when the uri matches a route', function () {
         beforeEach(function () {
-          spyOn( subject, 'getRouteForURI' ).andReturn({
+          spyOn( subject, 'createRouteForURI' ).andReturn({
             matchedRoute: '/users/:uuid',
             actions: [ { method: 'show', target: usersTarget } ],
             options: [ { leftNav: true }, { showLayout: false } ]

--- a/spec/request_spec.js
+++ b/spec/request_spec.js
@@ -11,7 +11,7 @@ describe('Request', function () {
       var route = '/snap/:uuid/dawg/:section/bro';
 
       beforeEach(function () {
-        subject = navigator.getRequest(
+        subject = navigator.createRequest(
           '/snap/foo/dawg/bar/bro',
           null,
           route
@@ -38,7 +38,7 @@ describe('Request', function () {
       queryString = '?bro=foo&dawg=bar&baz=boo';
 
       beforeEach(function () {
-        subject = navigator.getRequest('/snap', queryString, route);
+        subject = navigator.createRequest('/snap', queryString, route);
       });
 
       it('extracts the query string params', function () {
@@ -53,7 +53,7 @@ describe('Request', function () {
     describe('using the rails convention for arrays in a query', function () {
       beforeEach(function () {
         queryString = '?bros[]=simon&bros[]=barnaby&chickens[]=earl&dinosaurs=fun';
-        subject = navigator.getRequest('/snap', queryString, route);
+        subject = navigator.createRequest('/snap', queryString, route);
       });
 
       it('stores values for the same key in an array', function () {
@@ -72,7 +72,7 @@ describe('Request', function () {
     describe('with an invalid query string key', function () {
       beforeEach(function () {
         queryString = '?bros=keith&bros-george';
-        subject = navigator.getRequest('/snap', queryString, route);
+        subject = navigator.createRequest('/snap', queryString, route);
       });
 
       it('includes the valid params', function () {
@@ -88,7 +88,7 @@ describe('Request', function () {
 
   describe('params', function () {
     beforeEach(function () {
-      subject = navigator.getRequest('/bro/bar', '?baz=boo', '/bro/:foo');
+      subject = navigator.createRequest('/bro/bar', '?baz=boo', '/bro/:foo');
     });
 
     it('is a merge of namedParams and queryParams', function () {

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -15,7 +15,7 @@ describe('Route', function () {
   describe('given a uri that doesnt match any routes', function () {
     beforeEach(function () {
       uri = '/fartblaherty';
-      subject = navigator.getRouteForURI(uri);
+      subject = navigator.createRouteForURI(uri);
     });
 
     it('doesnt return anything', function () {
@@ -37,7 +37,7 @@ describe('Route', function () {
           }
         };
 
-        subject = navigator.getRouteForURI(uri);
+        subject = navigator.createRouteForURI(uri);
       });
 
       it('returns the correct route properties', function () {
@@ -59,7 +59,7 @@ describe('Route', function () {
           '/:uuid': 'show'
         };
 
-        subject = navigator.getRouteForURI(uri);
+        subject = navigator.createRouteForURI(uri);
       });
 
       it('matches best', function () {
@@ -96,7 +96,7 @@ describe('Route', function () {
           }
         };
 
-        subject = navigator.getRouteForURI(uri);
+        subject = navigator.createRouteForURI(uri);
       });
 
       it('returns the correct route properties', function () {
@@ -117,7 +117,7 @@ describe('Route', function () {
             options: { showLayout: true }
           }
 
-          subject = navigator.getRouteForURI(uri);
+          subject = navigator.createRouteForURI(uri);
         });
 
         it('includes those options in the routes object', function () {
@@ -133,7 +133,7 @@ describe('Route', function () {
               options: { renderBunnies: true }
             };
 
-            subject = navigator.getRouteForURI(uri);
+            subject = navigator.createRouteForURI(uri);
           });
 
           it('merges the options into one object', function () {
@@ -153,7 +153,7 @@ describe('Route', function () {
               options: { showLayout: false }
             };
 
-            subject = navigator.getRouteForURI(uri);
+            subject = navigator.createRouteForURI(uri);
           });
 
           it('gives precedence to the deeper option', function () {
@@ -169,7 +169,7 @@ describe('Route', function () {
               options: { renderCats: true }
             };
 
-            subject = navigator.getRouteForURI(uri);
+            subject = navigator.createRouteForURI(uri);
           });
 
           it('merges the options into one object', function () {


### PR DESCRIPTION
Expose the current request via Aviator.getCurrentRequest (this calls
Navigator#getCurrentRequest and return the internal _request property
which is set during dispatch).

Internal API Changes (for better consistency):
- Add Navigator#getCurrentRequest
- Rename Navigator#getURI to Navigator#getCurrentURI
- Rename Navigator#getRequest to Navigator#createRequest
- Rename Navigator#getRouteForURI to Navigator#createRouteForURI

External API Changes:
- Add Aviator.getCurrentRequest
- Rename Aviator.getURI to Aviator.getCurrentURI

@barnabyc @flahertyb 
