### PR TITLE
Add queryParam serialization to `navigate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ look like this `"/admin#/users/all"`.
 If you wish to replace the history item instead pushing to the history list
 call `navigate` with the replace option: `Aviator.navigate('/users/all', { replace: true });`
 
+Pass in the `queryParams` option that will be parsed into a queryString and added
+to the navigated uri:
+
+`Aviator.navigate('/users', { queryParams: { filter: [1,2] }});` will navigate to `"/users?filter[]=1&filter[]=2"`
+
 ### `Aviator.refresh`
 
 re-dispatch the current uri

--- a/spec/aviator_spec.js
+++ b/spec/aviator_spec.js
@@ -102,4 +102,18 @@ describe('Aviator', function () {
     });
   });
 
+  describe('.serializeQueryParams', function () {
+    beforeEach(function () {
+      spyOn( _navigator, 'serializeQueryParams' );
+
+      subject.serializeQueryParams({ foo: 'bar' });
+    });
+
+    it('calls serializeQueryParams on the navigator', function () {
+      expect( _navigator.serializeQueryParams ).toHaveBeenCalledWith({
+        foo: 'bar'
+      });
+    });
+  });
+
 });

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -211,6 +211,22 @@ describe('Navigator', function () {
           expect(window.history.replaceState).toHaveBeenCalled();
         });
       });
+
+      describe('when called with queryParams', function () {
+        it('serializes the query params into the url', function () {
+          var spy = spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
+            expect( a ).toEqual( 'navigate' );
+            expect( b ).toBe( '' );
+            expect( c ).toBe( '/_SpecRunner.html/foo/bar?baz=boo&userIds[]=2&userIds[]=3' );
+          });
+          subject.navigate('/foo/bar', {
+            queryParams: {
+              baz: 'boo',
+              userIds: [2,3]
+            }
+          });
+        });
+      });
     });
 
     describe('with push state disabled', function () {


### PR DESCRIPTION
Pass in the `queryParams` option that will be parsed into a queryString
and added to the navigated uri:

`Aviator.navigate('/users', { queryParams: { filter: [1,2] }});`
will navigate to `"/users?filter[]=1&filter[]=2"`

@barnabyc @flahertyb 
