### PR TITLE
navigate to url without calling target action

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ If you wish to replace the history item instead pushing to the history list
 call `navigate` with the replace option: `Aviator.navigate('/users/all', { replace: true });`
 
 Pass in the `queryParams` option that will be parsed into a queryString and added
-to the navigated uri:
+to the navigated uri: `Aviator.navigate('/users', { queryParams: { filter: [1,2] }});` will navigate to `"/users?filter[]=1&filter[]=2"`
 
-`Aviator.navigate('/users', { queryParams: { filter: [1,2] }});` will navigate to `"/users?filter[]=1&filter[]=2"`
+If you wish to change the url, but not have it call the route target, pass in `{ silent: true }` like so
+`Aviator.navigate('/users', { silent: true });`
 
 ### `Aviator.refresh`
 

--- a/aviator.js
+++ b/aviator.js
@@ -231,7 +231,7 @@
       var value,
           action = {
             target: routeLevel.target,
-            method:    null
+            method: null
           };
 
       for (var key in routeLevel) {
@@ -367,6 +367,7 @@
   **/
   var Navigator = function () {
     this._routes = null;
+    this._silent = false;
   };
 
   Navigator.prototype = {
@@ -484,7 +485,11 @@
     @method onURIChange
     **/
     onURIChange: function () {
-      this.dispatch();
+      if (!this._silent) {
+        this.dispatch();
+      }
+
+      this._silent = false;
     },
 
     /**
@@ -532,6 +537,10 @@
 
       if (options.queryParams) {
         uri += this.serializeQueryParams(options.queryParams);
+      }
+
+      if (options.silent) {
+        this._silent = true;
       }
 
       if (this.pushStateEnabled) {

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -211,22 +211,6 @@ describe('Navigator', function () {
           expect(window.history.replaceState).toHaveBeenCalled();
         });
       });
-
-      describe('when called with queryParams', function () {
-        it('serializes the query params into the url', function () {
-          var spy = spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
-            expect( a ).toEqual( 'navigate' );
-            expect( b ).toBe( '' );
-            expect( c ).toBe( '/_SpecRunner.html/foo/bar?baz=boo&userIds[]=2&userIds[]=3' );
-          });
-          subject.navigate('/foo/bar', {
-            queryParams: {
-              baz: 'boo',
-              userIds: [2,3]
-            }
-          });
-        });
-      });
     });
 
     describe('with push state disabled', function () {
@@ -237,6 +221,38 @@ describe('Navigator', function () {
 
       it('changes the hash to the href', function () {
         expect( window.location.hash ).toBe( '#/foo/bar' );
+      });
+    });
+
+    describe('when called with silent: true', function () {
+      beforeEach(function () {
+        subject.pushStateEnabled = true;
+        spyOn( subject, 'dispatch' );
+      });
+
+      it('never calls dispatch', function () {
+        subject.navigate('/foo/bar', { silent: true });
+        expect( subject.dispatch ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when called with queryParams', function () {
+      beforeEach(function () {
+        spyOn( subject, 'onURIChange' );
+      });
+
+      it('serializes the query params into the url', function () {
+        var spy = spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
+          expect( a ).toEqual( 'navigate' );
+          expect( b ).toBe( '' );
+          expect( c ).toBe( '/_SpecRunner.html/foo/bar?baz=boo&userIds[]=2&userIds[]=3' );
+        });
+        subject.navigate('/foo/bar', {
+          queryParams: {
+            baz: 'boo',
+            userIds: [2,3]
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
Pass in `{ silent: true }` to `Aviator.navigate` to change the url
without calling the matching target action (avoids calling `dispatch`)

@barnabyc @flahertyb 
