### PR TITLE
Navigate with named params

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ call `navigate` with the replace option: `Aviator.navigate('/users/all', { repla
 Pass in the `queryParams` option that will be parsed into a queryString and added
 to the navigated uri: `Aviator.navigate('/users', { queryParams: { filter: [1,2] }});` will navigate to `"/users?filter[]=1&filter[]=2"`
 
+Pass in the `namedParams` option to interpolate params into the url before navigate to it:
+`Aviator.navigate('/users/:id/edit', { namedParams: { id: 3 });` will navigate to `"/users/3/edit"`
+
 If you wish to change the url, but not have it call the route target, pass in `{ silent: true }` like so
 `Aviator.navigate('/users', { silent: true });`
 

--- a/aviator.js
+++ b/aviator.js
@@ -533,10 +533,20 @@
     @param {Object} [options]
     **/
     navigate: function (uri, options) {
-      var options = options || {};
+      var options = options || {},
+          namedParams = options.namedParams,
+          queryParams = options.queryParams;
 
-      if (options.queryParams) {
-        uri += this.serializeQueryParams(options.queryParams);
+      if (queryParams) {
+        uri += this.serializeQueryParams(queryParams);
+      }
+
+      if (namedParams) {
+        for (var p in namedParams) {
+          if (namedParams.hasOwnProperty(p)) {
+            uri = uri.replace(':' + p, namedParams[p]);
+          }
+        }
       }
 
       if (options.silent) {

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -236,6 +236,25 @@ describe('Navigator', function () {
       });
     });
 
+    describe('when called with namedParams and a route', function () {
+      beforeEach(function () {
+        spyOn( subject, 'onURIChange' );
+      });
+
+      it('navigates to a uri generate from the route and the namedParams', function () {
+        var spy = spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
+          expect( a ).toEqual( 'navigate' );
+          expect( b ).toBe( '' );
+          expect( c ).toBe( '/_SpecRunner.html/foo/bar/baz' );
+        });
+        subject.navigate('/foo/:named/baz', {
+          namedParams: {
+            named: 'bar'
+          }
+        });
+      });
+    });
+
     describe('when called with queryParams', function () {
       beforeEach(function () {
         spyOn( subject, 'onURIChange' );


### PR DESCRIPTION
Pass in the `namedParams` option to interpolate params into the url before
navigate to it:
`Aviator.navigate('/users/:id/edit', { namedParams: { id: 3 });`
will navigate to `"/users/3/edit"`

@barnabyc @flahertyb 
