### PR TITLE
Add Aviator.rewriteRouteTo

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -208,6 +208,24 @@ window.Aviator = {
   **/
   refresh: function () {
     this._navigator.refresh();
+  },
+
+  /**
+  @method rewriteRouteTo
+  **/
+  rewriteRouteTo: function (newRoute) {
+    var target = {
+      rewrite: function (request) {
+        Aviator.navigate(newRoute, {
+          namedParams: request.namedParams
+        });
+      }
+    };
+
+    return {
+      target: target,
+      '/': 'rewrite'
+    };
   }
 
 };

--- a/spec/aviator_spec.js
+++ b/spec/aviator_spec.js
@@ -116,4 +116,28 @@ describe('Aviator', function () {
     });
   });
 
+  describe('.rewriteRouteTo', function () {
+    var target;
+
+    beforeEach(function () {
+      target = subject.rewriteRouteTo('/foo/bar').target;
+    });
+
+    describe('the returned route target action', function () {
+      beforeEach(function () {
+        spyOn( Aviator, 'navigate' );
+      });
+
+      it('calls Aviator.navigate with the given route', function () {
+        target.rewrite({ namedParams: { baz: 'boo' } });
+
+        expect( Aviator.navigate ).toHaveBeenCalledWith(
+          '/foo/bar',
+          { namedParams: { baz: 'boo' } }
+        );
+
+      });
+    });
+  });
+
 });

--- a/src/main.js
+++ b/src/main.js
@@ -105,6 +105,26 @@ window.Aviator = {
   **/
   refresh: function () {
     this._navigator.refresh();
+  },
+
+  /**
+  @method rewriteRouteTo
+  @param {String} newRoute
+  @return {Object}
+  **/
+  rewriteRouteTo: function (newRoute) {
+    var target = {
+      rewrite: function (request) {
+        Aviator.navigate(newRoute, {
+          namedParams: request.namedParams
+        });
+      }
+    };
+
+    return {
+      target: target,
+      '/': 'rewrite'
+    };
   }
 
 };


### PR DESCRIPTION
Add simple helper for route descriptions so you can write things like
this:

``` javascript
Aviator.setRoutes({
  '/foo': {
    '/bar': Aviator.rewriteRouteTo('/baz')
  },
  '/baz': {
    target: bazTarget,
    '/': 'index'
  }
});
```

This fixes https://github.com/swipely/aviator/issues/34

@barnabyc @flahertyb 
