### PR TITLE
Don't rely on ev.state to detirmine initial load

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -252,6 +252,7 @@ var Navigator = function () {
   this._routes  = null;
   this._exits   = [];
   this._silent  = false;
+  this._dispatchingStarted = false;
 };
 
 Navigator.prototype = {
@@ -352,6 +353,10 @@ Navigator.prototype = {
 
     // collect exits of the current matching route
     this._exits = route.exits;
+
+    if (!this._dispatchingStarted) {
+      this._dispatchingStarted = true;
+    }
   },
 
   /**
@@ -366,15 +371,17 @@ Navigator.prototype = {
   },
 
   /**
-  Some browsers fire 'popstate' on the initial page load
-  with a null state object. In those cases we don't want
-  to trigger the uri change.
-
   @method onPopState
   @param {Event}
   **/
   onPopState: function (ev) {
-    if (ev.state) this.onURIChange();
+    // Some browsers fire 'popstate' on the initial page load with a null state
+    // object. We always want manual control over the initial page dispatch, so
+    // prevent any popStates from changing the url until we have started
+    // dispatching.
+    if (this._dispatchingStarted) {
+      this.onURIChange();
+    }
   },
 
   /**

--- a/spec/aviator_spec.js
+++ b/spec/aviator_spec.js
@@ -51,7 +51,6 @@ describe('Aviator', function () {
     it('calls dispatch on the private navigator object', function () {
       expect( _navigator.dispatch ).toHaveBeenCalled();
     });
-
   });
 
   describe('.getCurrentRequest', function () {

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -384,6 +384,18 @@ describe('Navigator', function () {
         });
       });
     });
+
+    describe('when _dispatchingStarted is false', function () {
+      beforeEach(function () {
+        spyOn( subject, 'createRouteForURI' ).andReturn({ matchedRoute: '', actions: [], exits: [], options: {}});
+        subject._dispatchingStarted = false;
+      });
+
+      it('sets it to true', function () {
+        subject.dispatch();
+        expect( subject._dispatchingStarted ).toBe( true );
+      });
+    });
   });
 
   describe('#_invokeActions', function () {
@@ -431,6 +443,34 @@ describe('Navigator', function () {
 
         expect( target.actionThree ).not.toHaveBeenCalled();
         expect( target.actionFour ).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('onPopState', function () {
+    beforeEach(function () {
+      spyOn( subject, 'onURIChange' );
+    });
+
+    describe('when `_dispatchingStarted` is false', function () {
+      beforeEach(function () {
+        subject._dispatchingStarted = false;
+      });
+
+      it('does not calls onURIChange', function () {
+        subject.onPopState();
+        expect( subject.onURIChange ).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when `_dispatchingStarted` is true', function () {
+      beforeEach(function () {
+        subject._dispatchingStarted = true;
+      });
+
+      it('calls onURIChange', function () {
+        subject.onPopState();
+        expect( subject.onURIChange ).toHaveBeenCalled();
       });
     });
   });

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -16,6 +16,7 @@ var Navigator = function () {
   this._routes  = null;
   this._exits   = [];
   this._silent  = false;
+  this._dispatchingStarted = false;
 };
 
 Navigator.prototype = {
@@ -116,6 +117,10 @@ Navigator.prototype = {
 
     // collect exits of the current matching route
     this._exits = route.exits;
+
+    if (!this._dispatchingStarted) {
+      this._dispatchingStarted = true;
+    }
   },
 
   /**
@@ -130,15 +135,17 @@ Navigator.prototype = {
   },
 
   /**
-  Some browsers fire 'popstate' on the initial page load
-  with a null state object. In those cases we don't want
-  to trigger the uri change.
-
   @method onPopState
   @param {Event}
   **/
   onPopState: function (ev) {
-    if (ev.state) this.onURIChange();
+    // Some browsers fire 'popstate' on the initial page load with a null state
+    // object. We always want manual control over the initial page dispatch, so
+    // prevent any popStates from changing the url until we have started
+    // dispatching.
+    if (this._dispatchingStarted) {
+      this.onURIChange();
+    }
   },
 
   /**


### PR DESCRIPTION
Add a simple bool the prevents popState from affecting dispatching until
the first dispatch is called.

This should fix the issue where the initially entered page could be navigated back to using the back/forward buttons.

![](http://24.media.tumblr.com/tumblr_m9qz22up021rafcuao1_500.gif)

@barnabyc @flahertyb 
