### PR TITLE
navigate: Fallback to currentRequest.namedParams

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -1,4 +1,4 @@
-;(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 /**
 binds a function to a context
 
@@ -455,8 +455,13 @@ Navigator.prototype = {
   navigate: function (uri, options) {
     options = options || {};
 
-    var namedParams = options.namedParams,
-        queryParams = options.queryParams;
+    var request     = this.getCurrentRequest();
+    var namedParams = options.namedParams;
+    var queryParams = options.queryParams;
+
+    if (!namedParams && request) {
+      namedParams = request.namedParams;
+    }
 
     // halt any previous action invocations
     this._actions = [];
@@ -972,4 +977,3 @@ Route.prototype = {
 module.exports = Route;
 
 },{"./helpers":1}]},{},[2])
-;

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -399,6 +399,22 @@ describe('Navigator', function () {
       });
     });
 
+    describe('when not called with namedParams', function () {
+      beforeEach(function () {
+        spyOn( subject, 'onURIChange' );
+        spyOn( subject, 'getCurrentRequest' ).andReturn({ namedParams: { named: 'bar' } });
+        spyOn( window.history, 'pushState' ).andCallFake(function (a, b, c) {
+          expect( a ).toEqual( 'navigate' );
+          expect( b ).toBe( '' );
+          expect( c ).toBe( '/_SpecRunner.html/foo/bar/baz' );
+        });
+      });
+
+      it('uses the namedParams of the currentRequest', function () {
+        subject.navigate('/foo/:named/baz');
+      });
+    });
+
     describe('when called with queryParams', function () {
       beforeEach(function () {
         spyOn( subject, 'onURIChange' );

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -219,8 +219,13 @@ Navigator.prototype = {
   navigate: function (uri, options) {
     options = options || {};
 
-    var namedParams = options.namedParams,
-        queryParams = options.queryParams;
+    var request     = this.getCurrentRequest();
+    var namedParams = options.namedParams;
+    var queryParams = options.queryParams;
+
+    if (!namedParams && request) {
+      namedParams = request.namedParams;
+    }
 
     // halt any previous action invocations
     this._actions = [];


### PR DESCRIPTION
If navigate is called without namedParams, attempt to use the
namedParams of the current request instead.

This will allow anchors like this:
`<a class='navigate' href='/foo/:named/bar'>Click me</a>`

@barnabyc @flahertyb 
