### PR TITLE
Fix: silent #navigates doesn't store request

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -382,7 +382,10 @@ Navigator.prototype = {
 
     // temporary action array that can be halted
     this._actions = route.actions;
-    this._invokeActions(request, route.options);
+
+    if (!this._silent) {
+      this._invokeActions(request, route.options);
+    }
 
     // collect exits of the current matching route
     this._exits = route.exits;
@@ -396,10 +399,7 @@ Navigator.prototype = {
   @method onURIChange
   **/
   onURIChange: function () {
-    if (!this._silent) {
-      this.dispatch();
-    }
-
+    this.dispatch();
     this._silent = false;
   },
 

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -370,13 +370,33 @@ describe('Navigator', function () {
 
     describe('when called with silent: true', function () {
       beforeEach(function () {
+        spyOn( usersTarget, 'index' );
+
         subject.pushStateEnabled = true;
-        spyOn( subject, 'dispatch' );
+        subject._routes = routes;
+        subject._request = null;
       });
 
-      it('never calls dispatch', function () {
-        subject.navigate('/foo/bar', { silent: true });
-        expect( subject.dispatch ).not.toHaveBeenCalled();
+      it('stores the request as if it was a regular one', function () {
+        subject.navigate('/users', {
+          silent: true,
+          queryParams: { foo: 'bar' }
+        });
+
+        // TODO: better object comparision than JSON
+        expect( JSON.stringify(subject.getCurrentRequest()) ).toEqual(JSON.stringify({
+          namedParams: {},
+          queryParams: { foo: 'bar' },
+          params: { foo: 'bar' },
+          uri: '/users',
+          queryString: '?foo=bar',
+          matchedRoute: '/users'
+        }));
+      });
+
+      it('doesnt call the actions of the route target', function () {
+        subject.navigate('/users', { silent: true });
+        expect( usersTarget.index ).not.toHaveBeenCalled();
       });
     });
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -140,7 +140,10 @@ Navigator.prototype = {
 
     // temporary action array that can be halted
     this._actions = route.actions;
-    this._invokeActions(request, route.options);
+
+    if (!this._silent) {
+      this._invokeActions(request, route.options);
+    }
 
     // collect exits of the current matching route
     this._exits = route.exits;
@@ -154,10 +157,7 @@ Navigator.prototype = {
   @method onURIChange
   **/
   onURIChange: function () {
-    if (!this._silent) {
-      this.dispatch();
-    }
-
+    this.dispatch();
     this._silent = false;
   },
 


### PR DESCRIPTION
Previously #getCurrentRequest would return the previously navigated
request when #navigate was called with silent: true.
This was because #dispatch was skipped during silent: true runs.
Now instead we skip #_invokeActions

@barnabyc @flahertyb 