### PR TITLE
Add a not found matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ will be called in that order, and both will be passed the options object.
 #### Not Found Handlers
 
 Aviator allows you to specify a method to be called when no route matches via
-the `$notFound` key. Much like normal routes, these can be added on a
+the `notFound` key. Much like normal routes, these can be added on a
 scope-by-scope basis. When a route cannot be found, only the `/*` matcher, and
-the `$notFound` of the nearest scope will be called. Here is an example
+the `notFound` of the nearest scope will be called. Here is an example
 configuration.
 
 ```javascript
@@ -146,17 +146,15 @@ Aviator.setRoutes({
       target: ReputationTarget,
       '/': { method: 'show', options: { renderMarketingLayout: false } }
     },
-    $notFound: 'notFound'
+    notFound: 'notFound'
   }
 });
 ```
 
 Hitting either `/marketing/bad-route/` or `/marketing/reputation/bad-route/`
 will call the `MarketingTarget.show` and `MarketingTarget.notFound` methods.
-However, hitting `/bad-route/` will call nothing unless a `$notFound` matcher
+However, hitting `/bad-route/` will call nothing unless a `notFound` matcher
 is found in the root context.
-
-Note that $notFound was chosen as a key because `$`s are invalid in URLs.
 
 #### namedParams
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,36 @@ Upon hitting `"/marketing/reputation"`,
 `marketingTarget#show` and `reputationTarget#show`
 will be called in that order, and both will be passed the options object.
 
+
+#### Not Found Handlers
+
+Aviator allows you to specify a method to be called when no route matches via
+the `$notFound` key. Much like normal routes, these can be added on a
+scope-by-scope basis. When a route cannot be found, only the `/*` matcher, and
+the `$notFound` of the nearest scope will be called. Here is an example
+configuration.
+
+```javascript
+Aviator.setRoutes({
+  '/marketing': {
+    target: MarketingTarget,
+    '/*': 'show',
+    '/reputation': {
+      target: ReputationTarget,
+      '/': { method: 'show', options: { renderMarketingLayout: false } }
+    },
+    $notFound: 'notFound'
+  }
+});
+```
+
+Hitting either `/marketing/bad-route/` or `/marketing/reputation/bad-route/`
+will call the `MarketingTarget.show` and `MarketingTarget.notFound` methods.
+However, hitting `/bad-route/` will call nothing unless a `$notFound` matcher
+is found in the root context.
+
+Note that $notFound was chosen as a key because `$`s are invalid in URLs.
+
 #### namedParams
 
 ```javascript

--- a/aviator.js
+++ b/aviator.js
@@ -770,8 +770,10 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
+  this.notFound     = null;
+  this.fullMatch    = false;
 
-  this.match(routes);
+  this.matchOrNotFound(routes);
 
   this.uri = uri;
 };
@@ -779,11 +781,24 @@ var Route = function (routes, uri) {
 Route.prototype = {
 
   /**
+  Attempt to match the uri, or call a notFound handler if nothing matches.
+
+  @method matchOrNotFound
+  @param {Object} routeLevel
+  **/
+  matchOrNotFound: function (routeLevel) {
+    this.match(routeLevel);
+
+    if (!this.fullMatch && this.notFound) {
+      this.actions.push(this.notFound);
+    }
+  },
+
+  /**
   Matches the uri from the routes map.
 
   @method match
-  @param {String} routeLevel
-  @return {Object}
+  @param {Object} routeLevel
   **/
   match: function (routeLevel) {
     var value, action, target;
@@ -795,6 +810,14 @@ Route.prototype = {
     if (this.targets.length) {
       target = this.targets[this.targets.length - 1];
     }
+
+    if (routeLevel.$notFound && target[routeLevel.$notFound]) {
+      this.notFound = {
+        target: target,
+        method: routeLevel.$notFound
+      };
+    }
+
 
     action = {
       target: target,
@@ -834,6 +857,10 @@ Route.prototype = {
 
               // Adding the action
               this.actions.push(action);
+
+              if (key !== '/*') {
+                this.fullMatch = true;
+              }
             }
           }
           else if (value.hasOwnProperty('options')) {

--- a/aviator.js
+++ b/aviator.js
@@ -811,10 +811,10 @@ Route.prototype = {
       target = this.targets[this.targets.length - 1];
     }
 
-    if (routeLevel.$notFound && target[routeLevel.$notFound]) {
+    if (routeLevel.notFound && target[routeLevel.notFound]) {
       this.notFound = {
         target: target,
-        method: routeLevel.$notFound
+        method: routeLevel.notFound
       };
     }
 

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -182,7 +182,7 @@ describe('Navigator', function () {
 
       it('saves root', function () {
         expect( subject.root ).toBe( '/slash/badass' );
-      })
+      });
     });
 
     it('sets up listeners for all clicks', function () {
@@ -343,7 +343,6 @@ describe('Navigator', function () {
             );
           });
         });
-
       });
     });
 
@@ -364,6 +363,25 @@ describe('Navigator', function () {
 
         it('changes the hash to the href with a queryString', function () {
           expect( window.location.hash ).toBe( '#/foo/bar?baz=123' );
+        });
+      });
+    });
+
+    describe('when no route can be found', function () {
+      describe('and there is a $notFound key in the current context', function () {
+        xit('calls its $notFound function and none of the parent $notFound functions', function () {
+        });
+      });
+
+      describe('but there is no $notFound key in the current context', function () {
+        describe('and one of the parent elements has a $notFound key', function () {
+          xit('calls the parent $notFound function', function () {
+          });
+        });
+
+        describe('and none of the parent elements has a $notFound key', function () {
+          xit('only calls the relevant "/*" matchers', function () {
+          });
         });
       });
     });

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -29,7 +29,7 @@ describe('Navigator', function () {
         target: itemsTarget,
         '/*': 'redirect',
         '/list': 'list',
-        $notFound: 'notFound'
+        notFound: 'notFound'
       }
     };
   });
@@ -410,15 +410,15 @@ describe('Navigator', function () {
         });
       });
 
-      describe('and there is a $notFound matcher', function () {
-        it('calls the $notFound matcher', function () {
+      describe('and there is a notFound matcher', function () {
+        it('calls the notFound matcher', function () {
           subject.navigate('/items/404');
           expect( itemsTarget.notFound.call ).toHaveBeenCalled();
         });
       });
 
-      describe('and is no $notFound matcher', function () {
-        it('calls no $notFound matcher', function () {
+      describe('and is no notFound matcher', function () {
+        it('calls no notFound matcher', function () {
           subject.navigate('/users/404');
           expect( itemsTarget.notFound.call ).not.toHaveBeenCalled();
         });

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -1,15 +1,29 @@
 describe('Navigator', function () {
 
-  var subject, usersTarget, routes;
+  var subject, itemsTarget, usersTarget, routes;
 
   beforeEach(function () {
     subject = Aviator._navigator;
-    usersTarget = { index: function () {}, show: function () {}, exitIndex: function () {} };
+
+    itemsTarget = {
+      list: function() {},
+      notFound: function () {}
+    };
+    usersTarget = {
+      index: function () {},
+      show: function () {},
+      exitIndex: function () {},
+    };
 
     routes = {
       '/users': {
         target: usersTarget,
-        '/': 'index'
+        '/': 'index',
+      },
+      '/items': {
+        target: itemsTarget,
+        '/list': 'list',
+        $notFound: 'notFound'
       }
     };
   });
@@ -368,20 +382,24 @@ describe('Navigator', function () {
     });
 
     describe('when no route can be found', function () {
-      describe('and there is a $notFound key in the current context', function () {
-        xit('calls its $notFound function and none of the parent $notFound functions', function () {
+      beforeEach(function () {
+        spyOn( itemsTarget.notFound, 'call' );
+        subject.pushStateEnabled = true;
+        subject._routes = routes;
+        subject._request = null;
+      });
+
+      describe('and there is a $notFound matcher', function () {
+        it('calls the $notFound matcher', function () {
+          subject.navigate('/items/404');
+          expect( itemsTarget.notFound.call ).toHaveBeenCalled();
         });
       });
 
-      describe('but there is no $notFound key in the current context', function () {
-        describe('and one of the parent elements has a $notFound key', function () {
-          xit('calls the parent $notFound function', function () {
-          });
-        });
-
-        describe('and none of the parent elements has a $notFound key', function () {
-          xit('only calls the relevant "/*" matchers', function () {
-          });
+      describe('and is no $notFound matcher', function () {
+        it('calls no $notFound matcher', function () {
+          subject.navigate('/users/404');
+          expect( itemsTarget.notFound.call ).not.toHaveBeenCalled();
         });
       });
     });

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -6,7 +6,12 @@ describe('Navigator', function () {
     subject = Aviator._navigator;
 
     itemsTarget = {
-      list: function() {},
+      redirect: function (request) {
+        if (request.queryParams.redirect) {
+          subject.navigate(request.queryParams.redirect);
+        }
+      },
+      list: function () {},
       notFound: function () {}
     };
     usersTarget = {
@@ -22,6 +27,7 @@ describe('Navigator', function () {
       },
       '/items': {
         target: itemsTarget,
+        '/*': 'redirect',
         '/list': 'list',
         $notFound: 'notFound'
       }
@@ -387,6 +393,21 @@ describe('Navigator', function () {
         subject.pushStateEnabled = true;
         subject._routes = routes;
         subject._request = null;
+      });
+
+      describe('but there is a redirect in one of the /* matchers', function () {
+        beforeEach(function () {
+          spyOn( itemsTarget.list, 'call' );
+        });
+
+        it('redirects and does not call the notFound matcher', function () {
+          subject.navigate('/items/404', {
+            queryParams: { redirect: '/items/list' }
+          });
+
+          expect( itemsTarget.list.call ).toHaveBeenCalled();
+          expect( itemsTarget.notFound.call ).not.toHaveBeenCalled();
+        });
       });
 
       describe('and there is a $notFound matcher', function () {

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -17,27 +17,27 @@ describe('Route', function () {
 
     beforeEach(function () {
       notFoundTarget = {
+        before: function() {},
         test: function() {},
         notFound1: function () {},
         notFound2: function () {},
         notFound3: function () {}
       };
-      uri = '/fart/blaherty';
       navigator._routes = {
-        '/': {
-          target: notFoundTarget,
-          '/fart': {
-            '/blaherty': {
-              '/test': 'test',
-              $notFound: 'notFound1'
-            },
-            $notFound: 'notFound2'
+        target: notFoundTarget,
+        '/fart': {
+          '/*': 'before',
+          '/blaherty': {
+            '/test': 'test',
+            $notFound: 'notFound1'
           },
-          '/hom': {
-            '/tulihan': {
-            },
-            $notFound: 'notFound3'
-          }
+          $notFound: 'notFound2'
+        },
+        '/hom': {
+          '/tulihan': {
+            '/': 'test'
+          },
+          $notFound: 'notFound3'
         }
       };
     });
@@ -50,17 +50,17 @@ describe('Route', function () {
         });
 
         it('doesnt return anything', function () {
-          expect( subject.matchedRoute ).toBe( '' );
+          expect( subject.actions ).toEqual( [] );
         });
       });
 
       describe('and there is a $notFound matcher in a parent scope', function () {
         beforeEach(function () {
-          uri = '/hom/tulihan';
+          uri = '/hom/hulihan';
           subject = navigator.createRouteForURI(uri);
         });
 
-        xit('returns the nearest $notFound matcher', function () {
+        it('returns the nearest $notFound matcher', function () {
           expect( subject.actions ).toEqual(
             [{ method: 'notFound3', target: notFoundTarget }]
           );
@@ -70,14 +70,15 @@ describe('Route', function () {
 
     describe('when there is a $notFound matcher in the current scope', function () {
       beforeEach(function () {
-        uri = '/fart/blaherty/lol';
+        uri = '/fart/blaherty/taste';
         subject = navigator.createRouteForURI(uri);
       });
 
-      xit('returns the $notFound matcher in that scope only', function () {
-        expect( subject.actions ).toEqual(
-          [{ method: 'notFound1', target: notFoundTarget }]
-        );
+      it('returns the $notFound matcher in that scope only', function () {
+        expect( subject.actions ).toEqual([
+          { target: notFoundTarget, method: 'before' },
+          { target: notFoundTarget, method: 'notFound1' }
+        ]);
       });
     });
   });
@@ -127,7 +128,7 @@ describe('Route', function () {
       });
 
       it('uses the parent level target', function () {
-        expect( subject.matchedRoute ).toBe( '/users/:uuid/edit' )
+        expect( subject.matchedRoute ).toBe( '/users/:uuid/edit' );
         expect( subject.actions ).toEqual(
           [{ method: 'edit', target: usersTarget }]
         );
@@ -223,7 +224,7 @@ describe('Route', function () {
       });
 
       it('returns the correct route properties', function () {
-        expect( subject.matchedRoute ).toBe( '/users/:uuid/edit' )
+        expect( subject.matchedRoute ).toBe( '/users/:uuid/edit' );
         expect( subject.actions ).toEqual([
           { method: 'init', target: appTarget },
           { method: 'edit', target: userTarget }
@@ -238,7 +239,7 @@ describe('Route', function () {
           navigator._routes['/*'] = {
             method: 'init',
             options: { showLayout: true }
-          }
+          };
 
           subject = navigator.createRouteForURI(uri);
         });
@@ -323,7 +324,7 @@ describe('Route', function () {
       });
 
       it('returns the correct route properties', function () {
-        expect( subject.matchedRoute ).toBe( '/calendar/:date' )
+        expect( subject.matchedRoute ).toBe( '/calendar/:date' );
         expect( subject.actions ).toEqual(
           [{ method: 'show', target: usersTarget }]
         );
@@ -344,7 +345,7 @@ describe('Route', function () {
       });
 
       it('finds the correct action', function () {
-        expect( subject.matchedRoute ).toBe( '/users/type/admins/all' )
+        expect( subject.matchedRoute ).toBe( '/users/type/admins/all' );
         expect( subject.actions ).toEqual(
           [{ method: 'show', target: usersTarget }]
         );
@@ -363,7 +364,7 @@ describe('Route', function () {
         });
 
         it('finds the correct action', function () {
-          expect( subject.matchedRoute ).toBe( '/users/type/:kind/all' )
+          expect( subject.matchedRoute ).toBe( '/users/type/:kind/all' );
           expect( subject.actions ).toEqual(
             [{ method: 'show', target: usersTarget }]
           );
@@ -385,7 +386,7 @@ describe('Route', function () {
         });
 
         it('finds the correct action', function () {
-          expect( subject.matchedRoute ).toBe( '/users/type/:kind/all/:id' )
+          expect( subject.matchedRoute ).toBe( '/users/type/:kind/all/:id' );
           expect( subject.actions ).toEqual(
             [{ method: 'show', target: usersTarget }]
           );

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -29,21 +29,21 @@ describe('Route', function () {
           '/*': 'before',
           '/blaherty': {
             '/test': 'test',
-            $notFound: 'notFound1'
+            notFound: 'notFound1'
           },
-          $notFound: 'notFound2'
+          notFound: 'notFound2'
         },
         '/hom': {
           '/tulihan': {
             '/': 'test'
           },
-          $notFound: 'notFound3'
+          notFound: 'notFound3'
         }
       };
     });
 
-    describe('when there is no $notFound matcher in the current scope', function () {
-      describe('and there is no $notFound matcher in a parent scope', function () {
+    describe('when there is no notFound matcher in the current scope', function () {
+      describe('and there is no notFound matcher in a parent scope', function () {
         beforeEach(function () {
           uri = '/bad/route';
           subject = navigator.createRouteForURI(uri);
@@ -54,13 +54,13 @@ describe('Route', function () {
         });
       });
 
-      describe('and there is a $notFound matcher in a parent scope', function () {
+      describe('and there is a notFound matcher in a parent scope', function () {
         beforeEach(function () {
           uri = '/hom/hulihan';
           subject = navigator.createRouteForURI(uri);
         });
 
-        it('returns the nearest $notFound matcher', function () {
+        it('returns the nearest notFound matcher', function () {
           expect( subject.actions ).toEqual(
             [{ method: 'notFound3', target: notFoundTarget }]
           );
@@ -68,13 +68,13 @@ describe('Route', function () {
       });
     });
 
-    describe('when there is a $notFound matcher in the current scope', function () {
+    describe('when there is a notFound matcher in the current scope', function () {
       beforeEach(function () {
         uri = '/fart/blaherty/taste';
         subject = navigator.createRouteForURI(uri);
       });
 
-      it('returns the $notFound matcher in that scope only', function () {
+      it('returns the notFound matcher in that scope only', function () {
         expect( subject.actions ).toEqual([
           { target: notFoundTarget, method: 'before' },
           { target: notFoundTarget, method: 'notFound1' }

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -13,13 +13,72 @@ describe('Route', function () {
   });
 
   describe('given a uri that doesnt match any routes', function () {
+    var notFoundTarget;
+
     beforeEach(function () {
-      uri = '/fartblaherty';
-      subject = navigator.createRouteForURI(uri);
+      notFoundTarget = {
+        test: function() {},
+        notFound1: function () {},
+        notFound2: function () {},
+        notFound3: function () {}
+      };
+      uri = '/fart/blaherty';
+      navigator._routes = {
+        '/': {
+          target: notFoundTarget,
+          '/fart': {
+            '/blaherty': {
+              '/test': 'test',
+              $notFound: 'notFound1'
+            },
+            $notFound: 'notFound2'
+          },
+          '/hom': {
+            '/tulihan': {
+            },
+            $notFound: 'notFound3'
+          }
+        }
+      };
     });
 
-    it('doesnt return anything', function () {
-      expect( subject.matchedRoute ).toBe( '' );
+    describe('when there is no $notFound matcher in the current scope', function () {
+      describe('and there is no $notFound matcher in a parent scope', function () {
+        beforeEach(function () {
+          uri = '/bad/route';
+          subject = navigator.createRouteForURI(uri);
+        });
+
+        it('doesnt return anything', function () {
+          expect( subject.matchedRoute ).toBe( '' );
+        });
+      });
+
+      describe('and there is a $notFound matcher in a parent scope', function () {
+        beforeEach(function () {
+          uri = '/hom/tulihan';
+          subject = navigator.createRouteForURI(uri);
+        });
+
+        xit('returns the nearest $notFound matcher', function () {
+          expect( subject.actions ).toEqual(
+            [{ method: 'notFound3', target: notFoundTarget }]
+          );
+        });
+      });
+    });
+
+    describe('when there is a $notFound matcher in the current scope', function () {
+      beforeEach(function () {
+        uri = '/fart/blaherty/lol';
+        subject = navigator.createRouteForURI(uri);
+      });
+
+      xit('returns the $notFound matcher in that scope only', function () {
+        expect( subject.actions ).toEqual(
+          [{ method: 'notFound1', target: notFoundTarget }]
+        );
+      });
     });
   });
 
@@ -41,7 +100,7 @@ describe('Route', function () {
       });
 
       it('returns the correct route properties', function () {
-        expect( subject.matchedRoute ).toBe( '/users/:uuid' )
+        expect( subject.matchedRoute ).toBe( '/users/:uuid' );
         expect( subject.actions ).toEqual(
           [{ method: 'show', target: usersTarget }]
         );

--- a/src/route.js
+++ b/src/route.js
@@ -59,10 +59,10 @@ Route.prototype = {
       target = this.targets[this.targets.length - 1];
     }
 
-    if (routeLevel.$notFound && target[routeLevel.$notFound]) {
+    if (routeLevel.notFound && target[routeLevel.notFound]) {
       this.notFound = {
         target: target,
-        method: routeLevel.$notFound
+        method: routeLevel.notFound
       };
     }
 

--- a/src/route.js
+++ b/src/route.js
@@ -18,8 +18,10 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
+  this.notFound     = null;
+  this.fullMatch    = false;
 
-  this.match(routes);
+  this.matchOrNotFound(routes);
 
   this.uri = uri;
 };
@@ -27,11 +29,24 @@ var Route = function (routes, uri) {
 Route.prototype = {
 
   /**
+  Attempt to match the uri, or call a notFound handler if nothing matches.
+
+  @method matchOrNotFound
+  @param {Object} routeLevel
+  **/
+  matchOrNotFound: function (routeLevel) {
+    this.match(routeLevel);
+
+    if (!this.fullMatch && this.notFound) {
+      this.actions.push(this.notFound);
+    }
+  },
+
+  /**
   Matches the uri from the routes map.
 
   @method match
-  @param {String} routeLevel
-  @return {Object}
+  @param {Object} routeLevel
   **/
   match: function (routeLevel) {
     var value, action, target;
@@ -43,6 +58,14 @@ Route.prototype = {
     if (this.targets.length) {
       target = this.targets[this.targets.length - 1];
     }
+
+    if (routeLevel.$notFound && target[routeLevel.$notFound]) {
+      this.notFound = {
+        target: target,
+        method: routeLevel.$notFound
+      };
+    }
+
 
     action = {
       target: target,
@@ -82,6 +105,10 @@ Route.prototype = {
 
               // Adding the action
               this.actions.push(action);
+
+              if (key !== '/*') {
+                this.fullMatch = true;
+              }
             }
           }
           else if (value.hasOwnProperty('options')) {


### PR DESCRIPTION
@AdamEdgett @hojberg @tlunter @flahertyb @barnabyc @ermanc 

This pull request adds the ability to call a method when there is no matching route. Only one `$notFound` method will be called per page that cannot be found. For more information, see my changes to the `README`.