### PR TITLE
Allow routes to be specified as functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ Upon hitting `"/marketing/reputation"`,
 `marketingTarget#show` and `reputationTarget#show`
 will be called in that order, and both will be passed the options object.
 
+Finally, route handlers may also be specified as plain functions:
+
+```javascript
+Aviator.setRoutes({
+  '/users': {
+    target: UsersTarget,
+    '/*': 'beforeAll',
+    '/': function () {
+      // Handle the route here
+    }
+  }
+});
+```
+
+Upon hitting `"/users/"`, `usersTarget#beforeAll` and the anonymous function
+above will be called in that order.
+
+We encourage the use of targets over anonymous functions, but we provide this as
+an option in case it fits your stylistic needs.
 
 #### Not Found Handlers
 
@@ -161,6 +180,8 @@ Hitting either `/marketing/bad-route/` or `/marketing/reputation/bad-route/`
 will call the `MarketingTarget.show` and `MarketingTarget.notFound` methods.
 However, hitting `/bad-route/` will call nothing unless a `notFound` matcher
 is found in the root context.
+
+Not found handlers may also be specified using plain functions.
 
 #### namedParams
 

--- a/aviator.js
+++ b/aviator.js
@@ -1888,7 +1888,6 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
-  this.anonymous    = {};
   this.notFound     = null;
   this.fullMatch    = false;
 
@@ -1935,7 +1934,8 @@ Route.prototype = {
         target: target,
         method: routeLevel.notFound
       };
-    } else if (isFunc(routeLevel.notFound)) {
+    }
+    else if (isFunc(routeLevel.notFound)) {
       this.notFound = this.anonymousAction(routeLevel.notFound);
     }
 
@@ -2129,19 +2129,16 @@ Route.prototype = {
   },
 
   /**
-  Assign the given function to the next sequential key in the this.anonymous
-  object.
+  Create an action Object from the given function.
 
-  @method generateNotFoundAction
+  @method anonymousAction
   @param {Function} func the anonymous function to transform into an action.
   @return {Object} With a method key that maps to a generated String, and
   **/
   anonymousAction: function (func) {
-    var method = 'FUNCTION-' + Object.keys(this.anonymous).length;
-    this.anonymous[method] = func;
     return {
-      target: this.anonymous,
-      method: method
+      target: { lambda: func },
+      method: 'lambda'
     };
   }
 };

--- a/aviator.js
+++ b/aviator.js
@@ -1103,6 +1103,16 @@ var isArray = function (o) {
 };
 
 /**
+@method isFunc
+@param {any} val
+@return {Boolean}
+@private
+**/
+var isFunc = function (val) {
+  return typeof val === 'function';
+};
+
+/**
 @method isPlainObject
 @param {any} val
 @return {Boolean}
@@ -1130,6 +1140,7 @@ module.exports = {
   merge: merge,
   addEvent: addEvent,
   isArray: isArray,
+  isFunc: isFunc,
   isPlainObject: isPlainObject,
   isString: isString
 };
@@ -1511,8 +1522,10 @@ Navigator.prototype = {
   onBeforeUnload: function (ev) {
     var exitMessage = this.getExitMessage();
 
-    ev.returnValue = exitMessage;
-    return exitMessage;
+    if (exitMessage) {
+      ev.returnValue = exitMessage;
+      return exitMessage;
+    }
   },
 
   /**
@@ -1856,6 +1869,7 @@ module.exports = Request;
 },{"./helpers":7}],11:[function(require,module,exports){
 var helpers = require('./helpers'),
     merge = helpers.merge,
+    isFunc = helpers.isFunc,
     isString = helpers.isString,
     isPlainObject = helpers.isPlainObject;
 
@@ -1874,6 +1888,7 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
+  this.anonymous    = {};
   this.notFound     = null;
   this.fullMatch    = false;
 
@@ -1920,16 +1935,16 @@ Route.prototype = {
         target: target,
         method: routeLevel.notFound
       };
+    } else if (isFunc(routeLevel.notFound)) {
+      this.notFound = this.anonymousAction(routeLevel.notFound);
     }
-
-
-    action = {
-      target: target,
-      method: null
-    };
 
     for (var key in routeLevel) {
       if (routeLevel.hasOwnProperty(key)) {
+        action = {
+          target: target,
+          method: null
+        };
         value = routeLevel[key];
 
         if (this.isFragment(key) && this.isFragmentInURI(key)) {
@@ -1943,6 +1958,9 @@ Route.prototype = {
             if (!this.isNamedParam(key) || !action.method) {
               if (isString(value)) {
                 action.method = value;
+              }
+              else if (isFunc(value)) {
+                action = this.anonymousAction(value);
               }
               else {
                 action.method = value.method;
@@ -2098,7 +2116,7 @@ Route.prototype = {
   @return {Boolean}
   **/
   isActionDescriptor: function (val) {
-    return isString(val) || isPlainObject(val) && val.method;
+    return isString(val) || isFunc(val) || isPlainObject(val) && val.method;
   },
 
   /**
@@ -2108,6 +2126,23 @@ Route.prototype = {
   **/
   isNamedParam: function (fragment) {
     return fragment.indexOf('/:') === 0;
+  },
+
+  /**
+  Assign the given function to the next sequential key in the this.anonymous
+  object.
+
+  @method generateNotFoundAction
+  @param {Function} func the anonymous function to transform into an action.
+  @return {Object} With a method key that maps to a generated String, and
+  **/
+  anonymousAction: function (func) {
+    var method = 'FUNCTION-' + Object.keys(this.anonymous).length;
+    this.anonymous[method] = func;
+    return {
+      target: this.anonymous,
+      method: method
+    };
   }
 };
 

--- a/spec/route_spec.js
+++ b/spec/route_spec.js
@@ -1,6 +1,6 @@
 describe('Route', function () {
 
-  var routes, uri, subject, usersTarget, navigator;
+  var routes, uri, subject, usersTarget, navigator, invokeAction;
 
   beforeEach(function () {
     usersTarget = {
@@ -10,6 +10,9 @@ describe('Route', function () {
     };
     navigator = Aviator._navigator;
     navigator._routes = {};
+    invokeAction = function (action) {
+      return action.target[action.method]();
+    };
   });
 
   describe('given a uri that doesnt match any routes', function () {
@@ -62,11 +65,8 @@ describe('Route', function () {
         });
 
         it('returns the nearest notFound matcher', function () {
-          expect( subject.actions ).toEqual(
-            [{ method: 'FUNCTION-0', target: subject.anonymous }]
-          );
-
-          expect( subject.anonymous['FUNCTION-0']() ).toEqual(3);
+          expect( subject.actions.length ).toEqual( 1 );
+          expect( invokeAction(subject.actions[0]) ).toEqual( 3 );
         });
       });
     });
@@ -102,11 +102,9 @@ describe('Route', function () {
 
       it('returns the correct route properties', function () {
         expect( subject.matchedRoute ).toBe( '/test/good' );
-        expect( subject.actions ).toEqual([
-          { method: 'FUNCTION-0', target: subject.anonymous }
-        ]);
+        expect( subject.actions.length ).toEqual( 1 );
+        expect( invokeAction(subject.actions[0]) ).toEqual( 42 );
         expect( subject.options ).toEqual( {} );
-        expect( subject.anonymous['FUNCTION-0']() ).toEqual(42);
       });
     });
 
@@ -244,15 +242,15 @@ describe('Route', function () {
 
       it('returns the correct route properties', function () {
         expect( subject.matchedRoute ).toBe( '/users/:uuid/edit' );
-        expect( subject.actions ).toEqual([
-          { method: 'init', target: appTarget },
-          { method: 'FUNCTION-0', target: subject.anonymous },
-          { method: 'initUsers', target: userTarget },
-          { method: 'FUNCTION-1', target: subject.anonymous },
-        ]);
-        expect( subject.options ).toEqual( {} );
-        expect( subject.anonymous['FUNCTION-0']() ).toEqual(0);
-        expect( subject.anonymous['FUNCTION-1']() ).toEqual(1);
+        expect( subject.actions.length ).toEqual( 4 );
+        expect( subject.actions[0] ).toEqual(
+          { method: 'init', target: appTarget }
+        );
+        expect( invokeAction(subject.actions[1]) ).toEqual( 0 );
+        expect( subject.actions[2] ).toEqual(
+          { method: 'initUsers', target: userTarget }
+        );
+        expect( invokeAction(subject.actions[3]) ).toEqual( 1 );
       });
     });
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -92,6 +92,16 @@ var isArray = function (o) {
 };
 
 /**
+@method isFunc
+@param {any} val
+@return {Boolean}
+@private
+**/
+var isFunc = function (val) {
+  return typeof val === 'function';
+};
+
+/**
 @method isPlainObject
 @param {any} val
 @return {Boolean}
@@ -119,6 +129,7 @@ module.exports = {
   merge: merge,
   addEvent: addEvent,
   isArray: isArray,
+  isFunc: isFunc,
   isPlainObject: isPlainObject,
   isString: isString
 };

--- a/src/route.js
+++ b/src/route.js
@@ -1,5 +1,6 @@
 var helpers = require('./helpers'),
     merge = helpers.merge,
+    isFunc = helpers.isFunc,
     isString = helpers.isString,
     isPlainObject = helpers.isPlainObject;
 
@@ -18,6 +19,7 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
+  this.anonymous    = {};
   this.notFound     = null;
   this.fullMatch    = false;
 
@@ -65,15 +67,16 @@ Route.prototype = {
         method: routeLevel.notFound
       };
     }
-
-
-    action = {
-      target: target,
-      method: null
-    };
+    else if (isFunc(routeLevel.notFound)) {
+      this.notFound = this.anonymousAction(routeLevel.notFound);
+    }
 
     for (var key in routeLevel) {
       if (routeLevel.hasOwnProperty(key)) {
+        action = {
+          target: target,
+          method: null
+        };
         value = routeLevel[key];
 
         if (this.isFragment(key) && this.isFragmentInURI(key)) {
@@ -87,6 +90,9 @@ Route.prototype = {
             if (!this.isNamedParam(key) || !action.method) {
               if (isString(value)) {
                 action.method = value;
+              }
+              else if (isFunc(value)) {
+                action = this.anonymousAction(value);
               }
               else {
                 action.method = value.method;
@@ -242,7 +248,7 @@ Route.prototype = {
   @return {Boolean}
   **/
   isActionDescriptor: function (val) {
-    return isString(val) || isPlainObject(val) && val.method;
+    return isString(val) || isFunc(val) || isPlainObject(val) && val.method;
   },
 
   /**
@@ -252,6 +258,23 @@ Route.prototype = {
   **/
   isNamedParam: function (fragment) {
     return fragment.indexOf('/:') === 0;
+  },
+
+  /**
+  Assign the given function to the next sequential key in the this.anonymous
+  object.
+
+  @method generateNotFoundAction
+  @param {Function} func the anonymous function to transform into an action.
+  @return {Object} With a method key that maps to a generated String, and
+  **/
+  anonymousAction: function (func) {
+    var method = 'FUNCTION-' + Object.keys(this.anonymous).length;
+    this.anonymous[method] = func;
+    return {
+      target: this.anonymous,
+      method: method
+    };
   }
 };
 

--- a/src/route.js
+++ b/src/route.js
@@ -19,7 +19,6 @@ var Route = function (routes, uri) {
   this.actions      = [];
   this.exits        = [];
   this.options      = {};
-  this.anonymous    = {};
   this.notFound     = null;
   this.fullMatch    = false;
 
@@ -261,19 +260,16 @@ Route.prototype = {
   },
 
   /**
-  Assign the given function to the next sequential key in the this.anonymous
-  object.
+  Create an action Object from the given function.
 
-  @method generateNotFoundAction
+  @method anonymousAction
   @param {Function} func the anonymous function to transform into an action.
   @return {Object} With a method key that maps to a generated String, and
   **/
   anonymousAction: function (func) {
-    var method = 'FUNCTION-' + Object.keys(this.anonymous).length;
-    this.anonymous[method] = func;
     return {
-      target: this.anonymous,
-      method: method
+      target: { lambda: func },
+      method: 'lambda'
     };
   }
 };


### PR DESCRIPTION
### Anonymous Route Handlers

@hojberg @flahertyb @tlunter @AdamEdgett @barnabyc @ermanc

This pull request allows route handlers to be specified as anonymous functions in the arguments to `Aviator.setRoutes`.
#### Motivation

Aviator's current means of specifying route handlers, via route targets and method names, is useful for grouping the route handling logic of related routes. However, for simple applications it feels a little bit more cumbersome than need be. Consider this application:

``` javascript
var RootTarget = {
  beforeAll: function () {},
  home: function () {},
  about: function () {},
  contact: function () {},
  legal: function () {},
  menu: function () {},
  notFound: function () {}
};

Aviator.setRoutes({
  target: RootTarget,
  '/*': 'beforeAll',
  '/': 'home',
  '/about': 'about',
  '/contact': 'contact',
  '/legal': 'legal',
  '/menu': 'menu',
  notFound: 'notFound'
});

Aviator.dispatch();
```

The above example is not very DRY, since one essentially has to repeat the route name in the arguments to `Aviator.setRoutes` in the handler itself.
#### Description

This PR makes route targets optional by allowing the handlers to be specified as anonymous functions. Using these changes, the above example could be re-written like so:

``` javascript
Aviator.setRoutes({
  '/*': function () {},
  '/': function () {},
  '/about': function () {},
  '/contact': function () {},
  '/legal': function () {},
  '/menu': function () {},
  notFound: function () {}
});

Aviator.dispatch();
```

Although the above example is not modular, one can still break up related routes into separate objects or files. More complex applications may look something like this:

``` javascript
var MarketingRoutes = {
  '/*': function () {},
  '/': function () {},
  notFound: function () {}
};

var StoreRoutes = {
  '/:store': function () {}
};

var BrandRoutes = {
  '/*': function () {},
  '/': function () {},
  '/:brand_id': {
    '/': function () {},
    '/stores': StoreRoutes
  }
  notFound: function () {},
};

var Routes = {
  '/*': function () {},
  '/': function () {},
  notFound: function () {},
  '/marketing': MarketingRoutes,
  '/brands': BrandRoutes,
};

Aviator.setRoutes(Routes);

Aviator.dispatch();
```

Of course, there's no reason that this feature should conflict with the existing Aviator style. Below is an example of an application that uses both the route target/method style and anonymous function style.

``` javascript
var UsersTarget = {
  beforeAll: function () {},
  index: function () {},
  notFound: function () {}
};

var Routes = {
  '/*': function () {},
  '/': function () {},
  notFound: function () {},
  '/users': {
    target: UsersTarget,
    '/*': 'beforeAll',
    '/': 'index',
    notFound: 'notFound',
  }
};

Aviator.setRoutes(Routes);

Aviator.dispatch();
```

There should be good test coverage, but please call out anything I missed.
