### PR TITLE
Add nextRequest to exit functions

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -578,10 +578,10 @@ Navigator.prototype = {
   pop of any exits function and invoke them
 
   @method _invokeExits
-  @param {Request} request
+  @param {Request} nextRequest
   @protected
   **/
-  _invokeExits: function (request) {
+  _invokeExits: function (nextRequest) {
     var exit, target, method;
 
     while(this._exits.length) {
@@ -590,10 +590,10 @@ Navigator.prototype = {
       method = exit.method;
 
       if (!(method in target)) {
-        throw new Error("Can't call exit " + method + ' on target for uri ' + request.uri);
+        throw new Error("Can't call exit " + method + ' on target when changing uri to ' + request.uri);
       }
 
-      target[method].call(target);
+      target[method].call(target, nextRequest);
     }
   },
 

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -609,7 +609,7 @@ describe('Navigator', function () {
         });
 
         it('calls the previous target exit method', function () {
-          expect( usersTarget.exitIndex ).toHaveBeenCalled();
+          expect( usersTarget.exitIndex ).toHaveBeenCalledWith(subject.getCurrentRequest());
         });
       });
     });

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -327,10 +327,10 @@ Navigator.prototype = {
   pop of any exits function and invoke them
 
   @method _invokeExits
-  @param {Request} request
+  @param {Request} nextRequest
   @protected
   **/
-  _invokeExits: function (request) {
+  _invokeExits: function (nextRequest) {
     var exit, target, method;
 
     while(this._exits.length) {
@@ -339,10 +339,10 @@ Navigator.prototype = {
       method = exit.method;
 
       if (!(method in target)) {
-        throw new Error("Can't call exit " + method + ' on target for uri ' + request.uri);
+        throw new Error("Can't call exit " + method + ' on target when changing uri to ' + request.uri);
       }
 
-      target[method].call(target);
+      target[method].call(target, nextRequest);
     }
   },
 


### PR DESCRIPTION
@barnabyc @flahertyb @nahiluhmot 

It's useful to know the new url in an exit, in order to distinguish how far away from the target the user is navigating. For instance if its navigating to the same url with a different named param, there might not be a reason to clear whatever state the exit function needs to clear vs going to an entirely different page in the application.