### PR TITLE
Fix for popstate firing two times in Safari

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -547,7 +547,9 @@ Navigator.prototype = {
     var pushStateEnabled = this.pushStateEnabled;
 
     if (pushStateEnabled) {
-      addEvent(window, 'popstate', this.onPopState, this);
+      setTimeout(function() {
+        addEvent(window, 'popstate', this.onPopState, this);
+      }, 0);
     }
     else {
       addEvent(window, 'hashchange', this.onURIChange, this);

--- a/aviator.js
+++ b/aviator.js
@@ -547,8 +547,11 @@ Navigator.prototype = {
     var pushStateEnabled = this.pushStateEnabled;
 
     if (pushStateEnabled) {
+      // Popstate fired on initial page load causes double trigger
+      // Hack to prevent popState firing two times in Safari (workaround found here: https://github.com/visionmedia/page.js/commit/6e6af2f6c0d7638e06a5ea3de0ff808237bdf2ef)
+      var self = this;
       setTimeout(function() {
-        addEvent(window, 'popstate', this.onPopState, this);
+        addEvent(window, 'popstate', self.onPopState, self);
       }, 0);
     }
     else {

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -216,10 +216,11 @@ describe('Navigator', function () {
         subject.setup({ pushStateEnabled: true });
       });
 
-      it('listens for onpopstate', function () {
-        // workaround for hack (make test pass) 
+      it('listens for onpopstate', function (done) {
+        // workaround for hack (make test pass)
         setTimeout(function() {
           expect( window.addEventListener ).toHaveBeenCalled();
+          done();
         }, 0)
       });
     });

--- a/spec/navigator_spec.js
+++ b/spec/navigator_spec.js
@@ -217,7 +217,10 @@ describe('Navigator', function () {
       });
 
       it('listens for onpopstate', function () {
-        expect( window.addEventListener ).toHaveBeenCalled();
+        // workaround for hack (make test pass) 
+        setTimeout(function() {
+          expect( window.addEventListener ).toHaveBeenCalled();
+        }, 0)
       });
     });
 

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -296,7 +296,11 @@ Navigator.prototype = {
     var pushStateEnabled = this.pushStateEnabled;
 
     if (pushStateEnabled) {
-      addEvent(window, 'popstate', this.onPopState, this);
+      // Popstate fired on initial page load causes double trigger
+      // Hack to prevent popState firing two times in Safari (workaround found here: https://github.com/visionmedia/page.js/commit/6e6af2f6c0d7638e06a5ea3de0ff808237bdf2ef)
+      setTimeout(function() {
+        addEvent(window, 'popstate', this.onPopState, this);
+      }, 0);
     }
     else {
       addEvent(window, 'hashchange', this.onURIChange, this);

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -298,8 +298,9 @@ Navigator.prototype = {
     if (pushStateEnabled) {
       // Popstate fired on initial page load causes double trigger
       // Hack to prevent popState firing two times in Safari (workaround found here: https://github.com/visionmedia/page.js/commit/6e6af2f6c0d7638e06a5ea3de0ff808237bdf2ef)
+      var self = this;
       setTimeout(function() {
-        addEvent(window, 'popstate', this.onPopState, this);
+        addEvent(window, 'popstate', self.onPopState, self);
       }, 0);
     }
     else {


### PR DESCRIPTION
Popstate fired two times on initial load, found a fix/hack here: https://github.com/visionmedia/page.js/commit/6e6af2f6c0d7638e06a5ea3de0ff808237bdf2ef