### PR TITLE
With no root specified, don't error

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -627,9 +627,16 @@ Navigator.prototype = {
   @return {String} uri '/s/foo-bar'
   **/
   _removeURIRoot: function (uri) {
-    var rootRegex = new RegExp('^' + this.root);
+    var rootRegex;
 
-    return uri.replace(rootRegex, '');
+    if (this.root) {
+      rootRegex = new RegExp('^' + this.root);
+
+      return uri.replace(rootRegex, '');
+    }
+    else {
+      return uri;
+    }
   },
 
   /**

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -376,9 +376,16 @@ Navigator.prototype = {
   @return {String} uri '/s/foo-bar'
   **/
   _removeURIRoot: function (uri) {
-    var rootRegex = new RegExp('^' + this.root);
+    var rootRegex;
 
-    return uri.replace(rootRegex, '');
+    if (this.root) {
+      rootRegex = new RegExp('^' + this.root);
+
+      return uri.replace(rootRegex, '');
+    }
+    else {
+      return uri;
+    }
   },
 
   /**


### PR DESCRIPTION
Makes sense to me that `_removeURIRoot`, when there's no root, returns the given string. 

@hojberg @barnabyc 