### PR TITLE
Allow specification of never using hash routes

### DIFF
--- a/aviator.js
+++ b/aviator.js
@@ -136,6 +136,13 @@ var Aviator = {
   root: '',
 
   /**
+  @property fallbackToHashRoutes
+  @type {Boolean}
+  @default true
+  **/
+  fallbackToHashRoutes: true,
+
+  /**
   @property _navigator
   @type {Navigator}
 
@@ -160,9 +167,10 @@ var Aviator = {
     var navigator = this._navigator;
 
     navigator.setup({
-      pushStateEnabled: this.pushStateEnabled,
-      linkSelector:     this.linkSelector,
-      root:             this.root
+      fallbackToHashRoutes: this.fallbackToHashRoutes,
+      pushStateEnabled:     this.pushStateEnabled,
+      linkSelector:         this.linkSelector,
+      root:                 this.root
     });
 
     navigator.dispatch();
@@ -285,7 +293,11 @@ Navigator.prototype = {
       }
     }
 
-    this._attachEvents();
+    // If not using push state or hash routes, there's no
+    // need for Aviator to listen to any events.
+    if (this.pushStateEnabled || this.fallbackToHashRoutes) {
+      this._attachEvents();
+    }
   },
 
   /**
@@ -335,7 +347,7 @@ Navigator.prototype = {
   @return {String}
   **/
   getCurrentPathname: function () {
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return this._removeURIRoot(location.pathname);
     }
     else {
@@ -348,7 +360,7 @@ Navigator.prototype = {
   @return {String}
   **/
   getCurrentURI: function () {
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return this._removeURIRoot(location.pathname) + location.search;
     }
     else {
@@ -363,7 +375,7 @@ Navigator.prototype = {
   getQueryString: function () {
     var uri, queryString;
 
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return location.search || null;
     }
     else {
@@ -494,9 +506,13 @@ Navigator.prototype = {
 
       this.onURIChange();
     }
-    else {
+    else if (this.fallbackToHashRoutes) {
       if (options.replace) location.replace('#' + link);
       else location.hash = link;
+    }
+    else {
+      location.replace(this.root + link);
+      return;
     }
   },
 

--- a/src/main.js
+++ b/src/main.js
@@ -33,6 +33,13 @@ var Aviator = {
   root: '',
 
   /**
+  @property fallbackToHashRoutes
+  @type {Boolean}
+  @default true
+  **/
+  fallbackToHashRoutes: true,
+
+  /**
   @property _navigator
   @type {Navigator}
 
@@ -57,9 +64,10 @@ var Aviator = {
     var navigator = this._navigator;
 
     navigator.setup({
-      pushStateEnabled: this.pushStateEnabled,
-      linkSelector:     this.linkSelector,
-      root:             this.root
+      fallbackToHashRoutes: this.fallbackToHashRoutes,
+      pushStateEnabled:     this.pushStateEnabled,
+      linkSelector:         this.linkSelector,
+      root:                 this.root
     });
 
     navigator.dispatch();

--- a/src/navigator.js
+++ b/src/navigator.js
@@ -34,7 +34,11 @@ Navigator.prototype = {
       }
     }
 
-    this._attachEvents();
+    // If not using push state or hash routes, there's no
+    // need for Aviator to listen to any events.
+    if (this.pushStateEnabled || this.fallbackToHashRoutes) {
+      this._attachEvents();
+    }
   },
 
   /**
@@ -84,7 +88,7 @@ Navigator.prototype = {
   @return {String}
   **/
   getCurrentPathname: function () {
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return this._removeURIRoot(location.pathname);
     }
     else {
@@ -97,7 +101,7 @@ Navigator.prototype = {
   @return {String}
   **/
   getCurrentURI: function () {
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return this._removeURIRoot(location.pathname) + location.search;
     }
     else {
@@ -112,7 +116,7 @@ Navigator.prototype = {
   getQueryString: function () {
     var uri, queryString;
 
-    if (this.pushStateEnabled) {
+    if (this.pushStateEnabled || !this.fallbackToHashRoutes) {
       return location.search || null;
     }
     else {
@@ -243,9 +247,13 @@ Navigator.prototype = {
 
       this.onURIChange();
     }
-    else {
+    else if (this.fallbackToHashRoutes) {
       if (options.replace) location.replace('#' + link);
       else location.hash = link;
+    }
+    else {
+      location.replace(this.root + link);
+      return;
     }
   },
 


### PR DESCRIPTION
Some folks might not want to use hash routes, even if the browser doesn't support push state. So I've added a change such that you can specify `fallbackToHashRoutes` as `false`. Specifying this option means:

`Aviator.dispatch()` would still perform the right action based on the url, but calls to `navigate` trigger full page refreshes, links work as normal, and Aviator doesn't intercept calls to the back button. 

With this commit, we are skipping the whole `_attachEvents` step. To actually have links work as normal, when a root is specified, we need to actually still intercept `navigate` link clicks so as to prepend the root. 

@barnabyc @hojberg @nahiluhmot 