### PR TITLE
Ignore middle clicks for navigate onClick events

### DIFF
--- a/src/navigator.js
+++ b/src/navigator.js
@@ -185,7 +185,7 @@ Navigator.prototype = {
         pathname,
         uri;
 
-    if (ev.metaKey || ev.ctrlKey) return;
+    if (ev.button === 1 || ev.metaKey || ev.ctrlKey) return;
 
     // Sub optimal. It itererates through all ancestors on every single click :/
     while (target) {


### PR DESCRIPTION
As [someone who uses middle click](http://i.imgur.com/JqYTmjn.gif) a lot, I expect middle click to open the link in a new tab

This prevents middle clicks from getting handled by our click handler, which was firing a navigate, making  middle clicks behave the same as left clicks

@hojberg @barnabyc 