### PR TITLE
Adding installation with npm instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Aviator:
 
 [![Build Status](https://travis-ci.org/swipely/aviator.png)](https://travis-ci.org/swipely/aviator)
 
+## Install
+```shell
+npm install aviator
+```
+
 ## API
 
 Aviator exposes a small API:


### PR DESCRIPTION
I found the npm install instructions on a issue and thought it is useful to have it on README :smile: 